### PR TITLE
月次の勤務リスト表示

### DIFF
--- a/app/Http/Controllers/Work_timeController.php
+++ b/app/Http/Controllers/Work_timeController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
-// use Illuminate\Http\Request;
+use Illuminate\Http\Request;
 use App\Work_time;
 use Carbon\Carbon;
-use Request;
+// use Request;
 use Auth;
 use App\User;
 
@@ -62,11 +62,37 @@ class Work_timeController extends Controller
 
     public function showTimeList()
     {
-        $times = Work_time::all();
+        // 現在の時間を取得
+        $now = Carbon::now();
+
+        // 今月の値
+        // dd($now->month);
+
+        // 今年の値
+        // dd($now->year);
+
+        // 月初の日にちを取得
+        $dt_from = new \Carbon\Carbon();
+		$dt_from->startOfMonth();
+        // dd($dt_from);
+
+        // 月終わりの日にちを取得
+		$dt_to = new \Carbon\Carbon();
+		$dt_to->endOfMonth();
+        // dd($dt_to);
+
+        // start_timeが今月のデータを全て取得
+        $times = Work_time::whereBetween('start_time', [$dt_from, $dt_to])->get();
         // dd($times);
+
+        // ログインユーザーのidを取得
         $login_user_id = Auth::id();
+        // dd($login_user_id);
+
+        // ログインユーザーのデータを取得
         $user = User::where('id', $login_user_id)->first();
-        return view('timeList', ['times'=>$times, 'user'=>$user]);
+        
+        return view('timeList', ['times'=>$times, 'user'=>$user, 'year'=>$now->year, 'month'=>$now->month]);
     }
 
     public function showPersonalTimeList($id)
@@ -78,5 +104,27 @@ class Work_timeController extends Controller
         $user = User::where('id', $login_user_id)->first();
         // dd($user);
         return view('personalTimeList', ['times'=>$times, 'user'=>$user]);
+    }
+
+    public function search(Request $request)
+    {
+        // formから飛ばされた値を取得
+        $year = $request->year;
+        // dd($year);
+        $month = $request->month;
+        // dd($month);
+        
+        // formで検索された値から検索して値を取得
+        $times = Work_time::whereyear('start_time', $year)->wheremonth('start_time', $month)->get();
+        // dd($times);
+
+        // ログインユーザーのidを取得
+        $login_user_id = Auth::id();
+        // dd($login_user_id);
+
+        // ログインユーザーのデータを取得
+        $user = User::where('id', $login_user_id)->first();
+        
+        return view('timeList', ['times'=>$times, 'user'=>$user, 'year'=>$year, 'month'=>$month]);
     }
 }

--- a/app/Http/Controllers/Work_timeController.php
+++ b/app/Http/Controllers/Work_timeController.php
@@ -97,13 +97,37 @@ class Work_timeController extends Controller
 
     public function showPersonalTimeList($id)
     {
-        $times = Work_time::where('user_id', $id)->get();
+        // 現在の時間を取得
+        $now = Carbon::now();
+
+        // 今月の値
+        // dd($now->month);
+
+        // 今年の値
+        // dd($now->year);
+
+        // 月初の日にちを取得
+        $dt_from = new \Carbon\Carbon();
+		$dt_from->startOfMonth();
+        // dd($dt_from);
+
+        // 月終わりの日にちを取得
+		$dt_to = new \Carbon\Carbon();
+		$dt_to->endOfMonth();
+        // dd($dt_to);
+
+        // start_timeが今月のデータを全て取得
+        $times = Work_time::where('user_id', $id)->whereBetween('start_time', [$dt_from, $dt_to])->get();
         // dd($times);
+
+        // ログインユーザーのidを取得
         $login_user_id = Auth::id();
         // dd($login_user_id);
+
+        // ログインユーザーのデータを取得
         $user = User::where('id', $login_user_id)->first();
-        // dd($user);
-        return view('personalTimeList', ['times'=>$times, 'user'=>$user]);
+        
+        return view('personalTimeList', ['times'=>$times, 'user'=>$user, 'year'=>$now->year, 'month'=>$now->month]);
     }
 
     public function search(Request $request)

--- a/app/Http/Controllers/Work_timeController.php
+++ b/app/Http/Controllers/Work_timeController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+// use Illuminate\Http\Request;
 use App\Work_time;
 use Carbon\Carbon;
-// use Request;
+use Request;
 use Auth;
 use App\User;
 
@@ -133,9 +133,9 @@ class Work_timeController extends Controller
     public function search(Request $request)
     {
         // formから飛ばされた値を取得
-        $year = $request->year;
+        $year = Request::get('year');
         // dd($year);
-        $month = $request->month;
+        $month = Request::get('month');
         // dd($month);
         
         // formで検索された値から検索して値を取得
@@ -150,5 +150,27 @@ class Work_timeController extends Controller
         $user = User::where('id', $login_user_id)->first();
         
         return view('timeList', ['times'=>$times, 'user'=>$user, 'year'=>$year, 'month'=>$month]);
+    }
+
+    public function searchPersonal(Request $request)
+    {
+        // formから飛ばされた値を取得
+        $year = Request::get('year');
+        // dd($year);
+        $month = Request::get('month');
+        // dd($month);
+
+        // ログインユーザーのidを取得
+        $login_user_id = Auth::id();
+        // dd($login_user_id);
+        
+        // formで検索された値から検索して値を取得
+        $times = Work_time::where('user_id', $login_user_id)->whereyear('start_time', $year)->wheremonth('start_time', $month)->get();
+        // dd($times);
+
+        // ログインユーザーのデータを取得
+        $user = User::where('id', $login_user_id)->first();
+        
+        return view('personalTimeList', ['times'=>$times, 'user'=>$user, 'year'=>$year, 'month'=>$month]);
     }
 }

--- a/public/assets/css/timeline.css
+++ b/public/assets/css/timeline.css
@@ -10,3 +10,9 @@
   justify-content: center;
   align-items: center;
 }
+
+.pagenation_wrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}

--- a/public/assets/css/timeline.css
+++ b/public/assets/css/timeline.css
@@ -16,3 +16,31 @@
   justify-content: center;
   margin-top: 30px;
 }
+
+.search_form_wrapper {
+  width: 100%;
+  padding-top: 15px;
+}
+
+.search_form {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 300px;
+  margin: 0 auto;
+  padding: 10px;
+  border: 2px solid #636b6f;
+}
+
+.search_form_text {
+  padding: 0 10px;
+}
+
+
+.btn-secondary {
+  height: 30px;
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+}
+

--- a/resources/views/personalTimeList.blade.php
+++ b/resources/views/personalTimeList.blade.php
@@ -22,6 +22,33 @@
     </div>
   </header>
 
+  <div class="search_form_wrapper">
+    <form action="{{ route('timelist.search') }}" method = "POST" class="search_form">
+    @csrf
+      <select class="" aria-label="" name="year">
+        <option value="2021" selected>{{$year}}</option>
+        @for ($i = 2021; $i <= $year+3; $i++)
+          <option value={{$i}}>
+            {{$i}}
+          </option>
+        @endfor
+      </select>
+      <span class="search_form_text">年</span>
+      <select class="" aria-label="" name="month">
+        <option selected>{{$month}}</option>
+        @for ($i = 1; $i <= 12; $i++)
+          <option value={{$i}}>
+            {{$i}}
+          </option>
+        @endfor
+      </select>
+      <span class="search_form_text">月</span>
+      <div>
+        <button type="submit"  class="btn btn-secondary">検索</button>
+      </div>
+    </form>
+  </div>
+
   <div class="container">
     <table class="table">
       <thead>

--- a/resources/views/personalTimeList.blade.php
+++ b/resources/views/personalTimeList.blade.php
@@ -25,21 +25,31 @@
   <div class="search_form_wrapper">
     <form action="{{ route('timelist.searchPersonal') }}" method = "POST" class="search_form">
     @csrf
-      <select class="" aria-label="" name="year">
-        <option value="2021" selected>{{$year}}</option>
+    <select class="" aria-label="" name="year">
         @for ($i = 2021; $i <= $year+3; $i++)
-          <option value={{$i}}>
-            {{$i}}
-          </option>
+          @if($i==$year)
+            <option value={{$i}} selected>
+              {{$i}}
+            </option>
+          @else
+            <option value={{$i}}>
+              {{$i}}
+            </option>
+          @endif
         @endfor
       </select>
       <span class="search_form_text">年</span>
       <select class="" aria-label="" name="month">
-        <option selected>{{$month}}</option>
         @for ($i = 1; $i <= 12; $i++)
-          <option value={{$i}}>
-            {{$i}}
-          </option>
+          @if($i==$month)
+              <option value={{$i}} selected>
+                {{$i}}
+              </option>
+            @else
+              <option value={{$i}}>
+                {{$i}}
+              </option>
+            @endif
         @endfor
       </select>
       <span class="search_form_text">月</span>

--- a/resources/views/personalTimeList.blade.php
+++ b/resources/views/personalTimeList.blade.php
@@ -23,7 +23,7 @@
   </header>
 
   <div class="search_form_wrapper">
-    <form action="{{ route('timelist.search') }}" method = "POST" class="search_form">
+    <form action="{{ route('timelist.searchPersonal') }}" method = "POST" class="search_form">
     @csrf
       <select class="" aria-label="" name="year">
         <option value="2021" selected>{{$year}}</option>

--- a/resources/views/timeList.blade.php
+++ b/resources/views/timeList.blade.php
@@ -24,6 +24,28 @@
     </div>
   </header>
 
+  <form action="{{ route('timelist.search') }}" method = "POST">
+  @csrf
+    <select class="form-select form-select-sm" aria-label=".form-select-sm example" name="year">
+      <option value="2021" selected>{{$year}}</option>
+      @for ($i = 2021; $i <= $year+3; $i++)
+        <option value={{$i}}>
+          {{$i}}
+        </option>
+      @endfor
+    </select>
+    <select class="form-select form-select-sm" aria-label=".form-select-sm example" name="month">
+      <option selected>{{$month}}</option>
+      @for ($i = 1; $i <= 12; $i++)
+        <option value={{$i}}>
+          {{$i}}
+        </option>
+      @endfor
+    </select>
+    <div class="col-12">
+      <button type="submit"  class="btn btn-primary btn-sm">検索</button>
+    </div>
+  </form>
 
   <div class="container">
     <table class="table">
@@ -38,23 +60,23 @@
         </tr>
       </thead>
       <tbody>
-        @foreach ($times as $time)
-        <tr>
-          <td scope="row">{{ $time->start_time->format('Y/m/d') }}</td>
-          <td>{{ $time->user->name }}</td>
-          <td>{{ $time->start_time->format('H:i:s') }}</td>
-          @if($time->end_time == null)
-            <td>退勤記録なし</td>
-          @else
-            <td>{{ $time->end_time->format('H:i:s') }}</td>
-          @endif
-          <td>{{ $time->work_time }}</td>
-        </tr>
-        @endforeach
+          @foreach ($times as $time)
+          <tr>
+            <td scope="row">{{ $time->start_time->format('Y/m/d') }}</td>
+            <td>{{ $time->user->name }}</td>
+            <td>{{ $time->start_time->format('H:i:s') }}</td>
+            @if($time->end_time == null)
+              <td>退勤記録なし</td>
+            @else
+              <td>{{ $time->end_time->format('H:i:s') }}</td>
+            @endif
+            <td>{{ $time->work_time }}</td>
+          </tr>
+          @endforeach
       </tbody>
     </table>
   </div>
-
+  
 <footer>
   <p class="footer">Seed Box © 2021 - </p>
 </footer>

--- a/resources/views/timeList.blade.php
+++ b/resources/views/timeList.blade.php
@@ -28,20 +28,30 @@
     <form action="{{ route('timelist.search') }}" method = "POST" class="search_form">
     @csrf
       <select class="" aria-label="" name="year">
-        <option value="2021" selected>{{$year}}</option>
         @for ($i = 2021; $i <= $year+3; $i++)
-          <option value={{$i}}>
-            {{$i}}
-          </option>
+          @if($i==$year)
+            <option value={{$i}} selected>
+              {{$i}}
+            </option>
+          @else
+            <option value={{$i}}>
+              {{$i}}
+            </option>
+          @endif
         @endfor
       </select>
       <span class="search_form_text">年</span>
       <select class="" aria-label="" name="month">
-        <option selected>{{$month}}</option>
         @for ($i = 1; $i <= 12; $i++)
-          <option value={{$i}}>
-            {{$i}}
-          </option>
+          @if($i==$month)
+              <option value={{$i}} selected>
+                {{$i}}
+              </option>
+            @else
+              <option value={{$i}}>
+                {{$i}}
+              </option>
+            @endif
         @endfor
       </select>
       <span class="search_form_text">月</span>

--- a/resources/views/timeList.blade.php
+++ b/resources/views/timeList.blade.php
@@ -24,28 +24,32 @@
     </div>
   </header>
 
-  <form action="{{ route('timelist.search') }}" method = "POST">
-  @csrf
-    <select class="form-select form-select-sm" aria-label=".form-select-sm example" name="year">
-      <option value="2021" selected>{{$year}}</option>
-      @for ($i = 2021; $i <= $year+3; $i++)
-        <option value={{$i}}>
-          {{$i}}
-        </option>
-      @endfor
-    </select>
-    <select class="form-select form-select-sm" aria-label=".form-select-sm example" name="month">
-      <option selected>{{$month}}</option>
-      @for ($i = 1; $i <= 12; $i++)
-        <option value={{$i}}>
-          {{$i}}
-        </option>
-      @endfor
-    </select>
-    <div class="col-12">
-      <button type="submit"  class="btn btn-primary btn-sm">検索</button>
-    </div>
-  </form>
+  <div class="search_form_wrapper">
+    <form action="{{ route('timelist.search') }}" method = "POST" class="search_form">
+    @csrf
+      <select class="" aria-label="" name="year">
+        <option value="2021" selected>{{$year}}</option>
+        @for ($i = 2021; $i <= $year+3; $i++)
+          <option value={{$i}}>
+            {{$i}}
+          </option>
+        @endfor
+      </select>
+      <span class="search_form_text">年</span>
+      <select class="" aria-label="" name="month">
+        <option selected>{{$month}}</option>
+        @for ($i = 1; $i <= 12; $i++)
+          <option value={{$i}}>
+            {{$i}}
+          </option>
+        @endfor
+      </select>
+      <span class="search_form_text">月</span>
+      <div>
+        <button type="submit"  class="btn btn-secondary">検索</button>
+      </div>
+    </form>
+  </div>
 
   <div class="container">
     <table class="table">

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,3 +85,6 @@ Route::get('/personaltimelist/{id}', 'Work_timeController@showPersonalTimeList')
 // timelineの月次表示
 Route::post('/timelist/search', 'Work_timeController@search')->name('timelist.search');
 
+// personalTimelineの月次表示
+Route::post('/timelist/searchpersonal', 'Work_timeController@searchPersonal')->name('timelist.searchPersonal');
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,3 +82,6 @@ Auth::routes();
 Route::get('/timelist', 'Work_timeController@showTimeList')->name('timelist.index');
 Route::get('/personaltimelist/{id}', 'Work_timeController@showPersonalTimeList')->name('timelist.indexPersonal');
 
+// timelineの月次表示
+Route::post('/timelist/search', 'Work_timeController@search')->name('timelist.search');
+


### PR DESCRIPTION
## 機能概要
- timelistとpersonaltimelistの勤務記録を月次表示する
- 年、月を指定して、勤務記録を検索できる

## PR確認方法
1. 「feature/show_monthly_timeline」ブランチに移動する
2. php artisan serveをする
3. ブラウザ上でログインする（どのアカウントでも可能）
4. 「/timelist」ページに移動する（「/」ページの「TIMELIST」ボタンを押下）
5. 当月分の勤務記録（全員分）が表示される
6. 検索フォーム（ページ上部のプルダウンの検索バー）で、年・月を指定し、該当の勤務記録（全員分）が表示される
6. 「/personaltimelist/{id}」ページに移動する（「/timelist」ページの右上の「ログインユーザー名」ボタンを押下）
7. 当月分の勤務記録（ログインユーザーのみ）が表示される
8. 検索フォーム（ページ上部のプルダウンの検索バー）で、年・月を指定し、該当の勤務記録（ログインユーザーのみ）が表示される

## 確認していただきたいこと
- [ ] 「/timelist」ページで、当月分の勤務記録（全員分）が表示されること
- [ ] 「/personaltimelist/{id}」ページで、当月分の勤務記録（ログインユーザーのみ）が表示されること
- [ ] 「/timelist」ページで、検索機能が異常なく動作すること
- [ ] 「/personaltimelist/{id}」ページで、検索機能が異常なく動作すること